### PR TITLE
ci(security): Dependabot + Trivy image scan pilot (SCA)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  # npm dependencies (Next.js app) — SCA pilot per architecture#15 / msa#155
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  # Keep the GitHub Actions workflow files themselves patched too
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: Checkout code
@@ -38,6 +41,33 @@ jobs:
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.PROJECT_NAME }}:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.PROJECT_NAME }}:${{ github.sha }}
+
+      # DevSecOps SCA pilot (architecture#15 / msa#155): scan the image we just
+      # built/pushed for known OS + npm vulnerabilities. Report-only for now —
+      # TODO: once findings are triaged, set exit-code: '1' with
+      # severity: 'CRITICAL,HIGH' to actually gate the build/deploy.
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.PROJECT_NAME }}:${{ github.sha }}
+          format: "sarif"
+          output: "trivy-results.sarif"
+          severity: "CRITICAL,HIGH,MEDIUM"
+          exit-code: "0"
+
+      - name: Upload Trivy scan results as workflow artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: trivy-results-${{ github.sha }}
+          path: trivy-results.sarif
+          retention-days: 30
+
+      - name: Upload Trivy scan results to GitHub Code Scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4.37.7
+        with:
+          sarif_file: "trivy-results.sarif"
 
   deploy:
     needs: build-and-push


### PR DESCRIPTION
## What

DevSecOps SCA pilot (sub-slice of [architecture#15](https://github.com/lee-dohyun/architecture/issues/15), tracked in [architecture#17](https://github.com/lee-dohyun/architecture/issues/17)):

- **`.github/dependabot.yml`**: weekly version updates for `npm` (this app's deps) and `github-actions` (the workflow files themselves), `open-pull-requests-limit: 5`.
- **`.github/workflows/docker-image.yml`**: after the image is built and pushed, run `aquasecurity/trivy-action` against it (`CRITICAL,HIGH,MEDIUM`), upload the SARIF to GitHub Code Scanning and as a workflow artifact.

## Why

`store.front` was previously compromised via a Next.js RCE (CVE-2025-66478) — tracked as `msa#155`. `~/msa/AGENTS.md` has an explicit immutable rule not to defer dependency security patches, especially Next.js/Spring. This closes the gap between "the rule exists" and "something actually watches for it."

Confirms the need: enabling Dependabot alerts on this repo as part of this PR's setup immediately surfaced **30 existing vulnerability alerts** on current dependencies (1 critical / 30 high / 23 moderate / 2 low per GitHub's push summary — some may collapse on recompute).

## Report-only for now, on purpose

The Trivy step uses `exit-code: 0` — it will **not** fail the build or block deploy. This is the first rollout on a live service; findings need to be triaged before anything gates on them. There's a `TODO` comment in the workflow marking where to flip this to `exit-code: 1` with `severity: CRITICAL,HIGH` once that triage happens.

## Not in this PR

- No app/runtime code changes — CI/workflow config only.
- No new cluster infrastructure — everything here runs inside GitHub Actions.
- Does not merge/deploy anything — **left open for manual review**, since a `main` push on this repo triggers an immediate production redeploy per its CD setup.

## Verification done

- YAML parsed cleanly with PyYAML.
- Linted with `actionlint` (only pre-existing, unrelated finding: the self-hosted `k3s-home` runner label is unrecognized by actionlint, which is expected/false-positive for a custom self-hosted label).
- Manual review of the diff — additions are scoped to the two intended files.
