### PR TITLE
fix(ci): Dependabot PR에서 DockerHub 로그인/푸시 건너뛰기

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -21,6 +21,9 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to DockerHub
+        # Dependabot 이 만든 pull_request 에는 저장소 시크릿이 전달되지 않는다.
+        # 조건이 없으면 모든 Dependabot PR 에서 이 스텝이 실패해 CI 가 상시 빨간색이 된다.
+        if: github.event_name == 'push'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -37,7 +40,8 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          push: true
+          # PR 빌드가 latest 태그를 덮어쓰지 않게 한다(gateway#184 P2-1 이 이 저장소를 빠뜨렸음).
+          push: ${{ github.event_name == 'push' }}
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.PROJECT_NAME }}:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.PROJECT_NAME }}:${{ github.sha }}
@@ -47,6 +51,7 @@ jobs:
       # TODO: once findings are triaged, set exit-code: '1' with
       # severity: 'CRITICAL,HIGH' to actually gate the build/deploy.
       - name: Run Trivy vulnerability scanner
+        if: github.event_name == 'push'
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.PROJECT_NAME }}:${{ github.sha }}
@@ -56,7 +61,7 @@ jobs:
           exit-code: "0"
 
       - name: Upload Trivy scan results as workflow artifact
-        if: always()
+        if: always() && github.event_name == 'push'
         uses: actions/upload-artifact@v7
         with:
           name: trivy-results-${{ github.sha }}
@@ -64,7 +69,7 @@ jobs:
           retention-days: 30
 
       - name: Upload Trivy scan results to GitHub Code Scanning
-        if: always()
+        if: always() && github.event_name == 'push'
         uses: github/codeql-action/upload-sarif@v4.37.7
         with:
           sarif_file: "trivy-results.sarif"


### PR DESCRIPTION
Dependabot PR마다 `Docker Image CI`가 항상 실패하던 문제를 고친다.

**원인**: Dependabot이 만든 `pull_request` 이벤트에는 저장소 시크릿이 전달되지 않는데, `Log in to DockerHub` 스텝에 이벤트 조건이 없어 PR에서도 실행되고 `Username and password required`로 실패했다. 이어서 Trivy 업로드가 존재하지 않는 sarif를 올리려다 또 실패했다.

**왜 지금**: 2026-08-21에 배포한 PR 품질 게이트(`pr-check.yml`)가 실제로 결함을 잡기 시작했는데(Next 16.3.1 PR에서 `swcMinify` 타입 오류·`next lint` 제거 검출), 그 옆에 상시 빨간 X가 있으면 신호가 죽는다.

**변경**: `Log in to DockerHub`에 `if: github.event_name == 'push'` 추가. store.front는 추가로 `push: true` → `push: ${{ github.event_name == 'push' }}`(gateway#184 P2-1이 이 저장소를 빠뜨려 PR 빌드가 `latest`를 덮어쓸 수 있었다)와 Trivy 스텝 3개의 push 한정까지 포함.

PR 빌드는 여전히 이미지를 **빌드**하므로 빌드 깨짐은 그대로 걸러진다. 레지스트리에 올리지 않을 뿐이다.

Closes #209
