### PR TITLE
fix(ci): 시크릿 없는 PR 빌드에서 이미지 태그가 깨지지 않게 폴백 추가

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -35,6 +35,9 @@ jobs:
           PROJECT_NAME=$(jq -r .name package.json)
           echo "PROJECT_NAME=$PROJECT_NAME" >> $GITHUB_ENV
 
+      # Dependabot PR 에는 시크릿이 없어 DOCKERHUB_USERNAME 이 빈 문자열이 된다.
+      # 그대로 두면 태그가 "/<name>:latest" 가 되어 buildx 가 invalid reference 로 죽는다.
+      # push 하지 않는 PR 빌드에서는 태그 이름 자체가 의미 없으므로 폴백을 쓴다.
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
@@ -43,8 +46,8 @@ jobs:
           # PR 빌드가 latest 태그를 덮어쓰지 않게 한다(gateway#184 P2-1 이 이 저장소를 빠뜨렸음).
           push: ${{ github.event_name == 'push' }}
           tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.PROJECT_NAME }}:latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.PROJECT_NAME }}:${{ github.sha }}
+            ${{ secrets.DOCKERHUB_USERNAME || 'ci-local' }}/${{ env.PROJECT_NAME }}:latest
+            ${{ secrets.DOCKERHUB_USERNAME || 'ci-local' }}/${{ env.PROJECT_NAME }}:${{ github.sha }}
 
       # DevSecOps SCA pilot (architecture#15 / msa#155): scan the image we just
       # built/pushed for known OS + npm vulnerabilities. Report-only for now —
@@ -54,7 +57,7 @@ jobs:
         if: github.event_name == 'push'
         uses: aquasecurity/trivy-action@v0.36.0
         with:
-          image-ref: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.PROJECT_NAME }}:${{ github.sha }}
+          image-ref: ${{ secrets.DOCKERHUB_USERNAME || 'ci-local' }}/${{ env.PROJECT_NAME }}:${{ github.sha }}
           format: "sarif"
           output: "trivy-results.sarif"
           severity: "CRITICAL,HIGH,MEDIUM"


### PR DESCRIPTION
#209 후속. 로그인 스텝을 push 이벤트로 한정한 뒤 Dependabot PR을 리베이스해 실측했더니, **다음 단계에서 다시 실패**했다:

```
ERROR: failed to build: invalid tag "/store.front:latest": invalid reference format
```

`tags:`가 `${{ secrets.DOCKERHUB_USERNAME }}/${{ env.PROJECT_NAME }}` 형태인데, Dependabot PR에는 시크릿이 없어 앞부분이 **빈 문자열**이 되고 태그가 `/store.front:latest`가 된다. buildx는 push 여부와 무관하게 태그 형식을 검사하므로 여기서 죽는다.

**변경**: `${{ secrets.DOCKERHUB_USERNAME || 'ci-local' }}`로 폴백을 준다. PR 빌드는 어차피 레지스트리에 올리지 않으므로 이름은 의미가 없고, **빌드가 깨지는지 검사한다는 목적은 그대로 달성된다**. push 이벤트에서는 시크릿이 있으므로 기존과 동일하게 동작한다.

관련: #209
