### PR TITLE
docs(agents): 공통 캐논 최신화 — TDD/AI 에이전트 테스트 프로토콜 절 반영

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,7 @@ npm run lint
 
 ---
 
-<!-- canon:begin sha=2327991ef5aa src=~/msa/AGENTS.md -->
+<!-- canon:begin sha=7ab837cdce2d src=~/msa/AGENTS.md -->
 ## 공통 캐논 (모든 AI 도구 공통)
 
 > **공통 캐논 (자동 주입 — 손으로 고치지 말 것).** 원본은 `~/msa/AGENTS.md`이고 이 블록은
@@ -136,6 +136,14 @@ npm run lint
 - **모든 상태 변경(쓰기) API는 멱등해야 한다.** 재시도/중복 호출이 이중 차감·이중 결제가 되지 않게 멱등성 키(예: orderId) 기반 dedup을 넣는다 (posselect #211).
 - 클래스 레벨 `@Transactional(readOnly = true)`인 클래스에 쓰기 경로 추가 금지 — 전파 함정으로 UPDATE가 조용히 사라진다. 쓰기는 별도 클래스 또는 `REQUIRES_NEW` (posselect #211 롤백 사례).
 - **트랜잭션 전파·멱등성 변경은 단위 테스트로 검증이 성립하지 않는다.** 실제 DB 상태 변화 실측(같은 키로 2회 호출 → 1회만 반영)으로 검증하고, 실측 후 데이터 원복까지 한 세트로 수행 (posselect #211).
+
+### TDD / AI 에이전트 테스트 프로토콜
+- 새 기능·버그 수정은 가능한 범위에서 **실패하는 테스트 먼저 작성 → 통과하도록 구현 → 리팩터링** 순서로 진행한다. 순수 설정/인프라 변경처럼 테스트로 표현되지 않는 작업은 예외.
+- Test Pyramid: Unit(JUnit5/Vitest, 가장 많이) → Integration(Testcontainers 실DB, 서비스 경계 검증) → E2E(Playwright, 핵심 플로우만 적게). 계층별 책임과 저장소별 현황은 `architecture` 저장소 `docs/2026-08-21-test-pyramid-strategy.md` 참고.
+- **위 "트랜잭션 / 정합성" 절의 예외가 여기도 그대로 적용된다** — 트랜잭션 전파·멱등성 변경은 단위 테스트로 검증이 성립하지 않으므로 실제 DB 상태 실측으로 검증한다.
+- **커버리지는 리포트만 하고 게이트로 쓰지 않는다(2026-08-21 결정).** 대부분 저장소가 0%에서 시작해 즉시 임계값을 걸면 모든 PR이 막힌다 — CI가 커버리지를 아티팩트로 남기고, 수치가 쌓이면 추후 임계값 도입을 재검토한다.
+- 기존 테스트가 있는 저장소는 `verify.sh`(§5-1)가 이미 push 전 실행을 강제한다 — 새 테스트를 추가하는 순간부터 자동으로 강제 대상이 된다. 별도 CI 배선이 필요 없다.
+- 근거: architecture#14(장기 개선, TDD 도입), posselect-shell#26(Testcontainers 통합 테스트 표준, posselect #211 readOnly 전파 롤백 사례에서 도출).
 
 ### 보안 / 인가
 - **사용자 식별 키는 Keycloak sub(`X-User-Id`)만.** 이메일은 변경 가능하므로 소유자 키로 쓰지 않는다 (posselect #210).


### PR DESCRIPTION
PR #39 작업 중 발견: 이 저장소 AGENTS.md의 캐논 블록이 sha=2327991ef5aa로 고정돼 있어
`~/msa/AGENTS.md`에 이후 추가된 "TDD / AI 에이전트 테스트 프로토콜" 절(architecture#14 대응,
커버리지 게이트 미적용 결정 등)이 반영돼 있지 않았다. `sync-agents-canon.sh`로 최신
(sha=7ab837cdce2d) 상태로 갱신한다. 문서 전용 변경이라 verify.sh가 자동으로 검증을 건너뛴다.

Ref architecture#14