### PR TITLE
chore(lint): eslint-plugin-sonarjs 적용 — SonarQube 코드스멜 탐지 경량 대안

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import { dirname } from "path";
 import { fileURLToPath } from "url";
 import { FlatCompat } from "@eslint/eslintrc";
+import sonarjs from "eslint-plugin-sonarjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -9,8 +10,50 @@ const compat = new FlatCompat({
   baseDirectory: __dirname,
 });
 
+// SonarQube 룰셋의 코드스멜 탐지만 ESLint 플러그인으로 가져온 것이다(store.front#46).
+// SonarQube 서버 자체는 도입하지 않았다 — Postgres 백엔드를 요구하는 상시 서비스를
+// 단일 HDD 서버에 하나 더 얹는 비용이 이득보다 크다고 판단했다.
+//
+// recommended(217개 활성)를 그대로 error 로 둔다. 도입 시점에 기존 코드 위반이
+// 0건임을 실측했으므로(app/lib 24개 파일) error 가 당장 막는 것은 없고,
+// 앞으로 들어오는 위반만 걸린다. warn 으로 두면 `next lint` 가 경고에 exit 0 이라
+// scripts/verify.sh 의 push 게이트를 그냥 통과해 사실상 아무 효과가 없다.
+//
+// 아래 예외는 "정상적인 개발 행위를 막는" 룰만 추린 것이고, 4개 프론트 저장소가
+// 같은 목록을 공유한다(store.front#46 / customer.front#32 / product.front#25 /
+// admin.front#28). 기본 전제는 여전히 "룰이 아니라 코드가 틀렸다" 이다 —
+// 막힌다고 여기에 추가하지 말고, 추가한다면 그 판단 근거를 주석으로 남길 것.
+const SONARJS_OVERRIDES = {
+  // TODO/FIXME 주석을 쓰는 순간 push 가 막힌다. 이 저장소는 실제로 쓰고 있다.
+  "sonarjs/todo-tag": "off",
+  "sonarjs/fixme-tag": "off",
+  // 임계값(기본 15) 초과를 리팩터링 강제 사유로 삼을 만큼 신뢰도가 높지 않다. 신호만 남긴다.
+  "sonarjs/cognitive-complexity": "warn",
+  // 아래 둘은 JSX 다중 상태 렌더링의 표준 관용구를 그대로 걸어 버린다.
+  //   {loading ? <A/> : error ? <B/> : <C/>}
+  //   `/api/products${qs ? `?${qs}` : ""}`
+  // 실측(customer.front 3건 / product.front 6건)에서 걸린 코드가 전부 이 형태였고,
+  // 지적대로 고치면 JSX 가 더 읽기 어려워진다 — 룰이 코드보다 틀린 경우로 판단했다.
+  "sonarjs/no-nested-conditional": "warn",
+  "sonarjs/no-nested-template-literals": "warn",
+  // `export type Role = string` 같은 도메인 별칭을 걸러낸다. 타입 안전성은 못 주지만
+  // 문서 가치가 있어 의도적으로 쓰는 패턴이다. 다만 지적 자체는 타당하므로 신호는 남긴다.
+  "sonarjs/redundant-type-aliases": "warn",
+};
+
+const sonarjsRules = {
+  ...sonarjs.configs.recommended.rules,
+  ...SONARJS_OVERRIDES,
+};
+
 const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript"),
+  {
+    // 소스 코드만 대상. 설정 파일(*.mjs/*.config.ts)까지 걸면 노이즈만 는다.
+    files: ["app/**/*.{ts,tsx}", "lib/**/*.{ts,tsx}"],
+    plugins: sonarjs.configs.recommended.plugins,
+    rules: sonarjsRules,
+  },
 ];
 
 export default eslintConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@vitest/coverage-v8": "^4.1.11",
         "eslint": "^9",
         "eslint-config-next": "15.5.23",
+        "eslint-plugin-sonarjs": "^4.2.0",
         "jsdom": "^30.0.1",
         "tailwindcss": "^4",
         "typescript": "^5",
@@ -403,9 +404,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3249,6 +3250,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -4227,6 +4251,83 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/eslint-plugin-sonarjs": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.2.0.tgz",
+      "integrity": "sha512-bqADfuNtTL7VK6RU29eoiFTtaaBKIpVPuX3bOl+rBpWSBa0zIBVZlqZNZQjfP6s4iXkAJokv5IsD8OsACkwApg==",
+      "dev": true,
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "builtin-modules": "^3.3.0",
+        "bytes": "^3.1.2",
+        "functional-red-black-tree": "^1.0.1",
+        "globals": "^17.7.0",
+        "jsx-ast-utils-x": "^0.1.0",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^10.2.5",
+        "scslre": "^0.3.0",
+        "semver": "^7.8.5",
+        "ts-api-utils": "^2.5.0",
+        "typescript": ">=5 <6.1.0",
+        "yaml": "^2.9.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/globals": {
+      "version": "17.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
+      "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
@@ -4527,6 +4628,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
@@ -5452,6 +5560,16 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jsx-ast-utils-x": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils-x/-/jsx-ast-utils-x-0.1.0.tgz",
+      "integrity": "sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/keyv": {
@@ -6550,6 +6668,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/refa": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/refa/-/refa-0.12.1.tgz",
+      "integrity": "sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -6571,6 +6702,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp-ast-analysis": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.7.1.tgz",
+      "integrity": "sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.1"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/regexp.prototype.flags": {
@@ -6787,6 +6932,21 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "license": "MIT"
+    },
+    "node_modules/scslre": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.3.0.tgz",
+      "integrity": "sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.0",
+        "regexp-ast-analysis": "^0.7.0"
+      },
+      "engines": {
+        "node": "^14.0.0 || >=16.0.0"
+      }
     },
     "node_modules/semver": {
       "version": "7.8.5",
@@ -7419,9 +7579,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8285,6 +8445,22 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@vitest/coverage-v8": "^4.1.11",
     "eslint": "^9",
     "eslint-config-next": "15.5.23",
+    "eslint-plugin-sonarjs": "^4.2.0",
     "jsdom": "^30.0.1",
     "tailwindcss": "^4",
     "typescript": "^5",


### PR DESCRIPTION
Closes #46

SonarQube 셀프호스팅 대신 ESLint 플러그인으로 룰셋만 가져오는 경량 대안. **이 저장소가 파일럿**이고, 같은 설정을 customer.front#32 / product.front#25 / admin.front#28 에 전파했다. 4개 프론트가 동일한 override 목록을 공유한다.

## 레벨: error 212 / warn 5 / off 64

`next lint` 는 경고에 exit 0 이라, warn 으로 두면 `scripts/verify.sh` 의 push 게이트를 그냥 통과해 사실상 아무 효과가 없다. 도입 시점에 위반 0건을 실측했으므로 error 로 올려도 당장 막히는 것은 없고, 앞으로 들어오는 위반만 걸린다.

예외 6종은 **정상적인 코드를 막는** 룰만 추렸다:

| 룰 | 레벨 | 이유 |
|---|---|---|
| `todo-tag`, `fixme-tag` | off | TODO 주석을 쓰는 순간 push 가 막힌다 |
| `no-nested-conditional` | warn | `{loading ? <A/> : error ? <B/> : <C/>}` — JSX 다중 상태 렌더링의 표준 관용구 |
| `no-nested-template-literals` | warn | 위와 같은 성격 |
| `redundant-type-aliases` | warn | `export type Role = string` 같은 의도적 도메인 별칭 |
| `cognitive-complexity` | warn | 임계값(15) 초과를 리팩터링 강제 사유로 삼기엔 신뢰도가 낮다 |

**warn 인 것은 지적이 무의미해서가 아니라 강제할 근거가 약해서다.** off 가 아닌 이유이기도 하다.

이 저장소는 마침 위 JSX 패턴이 없어 위반 0건이었지만, 전파 대상 3곳에서 error 10건이 나왔고 전부 정상적인 코드였다. 그대로 뒀으면 누가 첫 중첩 삼항을 쓰는 순간 push 가 막혔을 것이다.

적용 범위는 `app/**`, `lib/**` 소스만. 설정 파일까지 걸면 노이즈만 는다.
**제품 코드는 한 줄도 고치지 않았다** — lint 도입과 코드 수정을 섞으면 회귀가 났을 때 원인이 갈린다.

## 검증

- `scripts/verify.sh` 통과 — typecheck / lint / test(5 passed)
- **`npm ci` 단독 EXIT 0** — #49 가 `pr-check.yml` 의 `|| npm install` 폴백을 제거했으므로 필수 조건이다
- 탐지 동작 확인 — 의도적 위반 파일에서 `sonarjs/no-identical-expressions` 검출

> 최초 올렸을 때는 lock 재동기화(2518줄)가 함께 들어 있었으나, 그 문제는 #49 가 main 에서 먼저 해결했다. 이 브랜치를 그 위로 리베이스해 **lock diff 는 sonarjs 추가분(188줄)만 남았다.**

## 다음 단계 (별건)

1. Trivy 게이팅 활성화 — 이미 10개 저장소에 report-only 로 배포됨(architecture#15/#17), `exit-code: '1'` 만 남았다
2. SpotBugs(백엔드) — `check` 바인딩이라 verify.sh(`gradlew test`)에서는 안 돌고 배포 워크플로(`gradlew build`)에서만 터진다. 별도 설계 필요