### PR TITLE
fix(docker): change base image to node:22-alpine and use npm ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine as base
+FROM node:22-alpine as base
 RUN apk add --no-cache g++ make py3-pip libc6-compat git
 WORKDIR /app
 COPY package*.json ./
@@ -7,7 +7,7 @@ EXPOSE 3000
 FROM base as builder
 WORKDIR /app
 COPY . .
-RUN npm install
+RUN npm ci
 RUN npm run build
 
 FROM base as production


### PR DESCRIPTION
Closes #50
(The lockfile was already synchronized in previous PR #49 / UI update, so npm ci works now.)