### PR TITLE
fix(home): 배너 캐러셀 좌우 스와이프 지원

### DIFF
--- a/components/BannerCarousel.test.tsx
+++ b/components/BannerCarousel.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import BannerCarousel from "./BannerCarousel";
+
+const banners = [
+  { id: 1, title: "Banner 1", subtitle: "sub1", imageUrl: null, link: "/a", bgColor: "#111" },
+  { id: 2, title: "Banner 2", subtitle: "sub2", imageUrl: null, link: "/b", bgColor: "#222" },
+  { id: 3, title: "Banner 3", subtitle: "sub3", imageUrl: null, link: "/c", bgColor: "#333" },
+];
+
+function swipe(container: HTMLElement, startX: number, endX: number) {
+  const el = container.firstElementChild as HTMLElement;
+  fireEvent.pointerDown(el, { clientX: startX, pointerId: 1 });
+  fireEvent.pointerMove(el, { clientX: endX, pointerId: 1 });
+  fireEvent.pointerUp(el, { clientX: endX, pointerId: 1 });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  // Element.setPointerCapture/releasePointerCapture are not implemented in jsdom.
+  Element.prototype.setPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("BannerCarousel swipe", () => {
+  it("moves to the next banner on a left swipe", () => {
+    const { container } = render(<BannerCarousel initialBanners={banners} />);
+    const first = screen.getByText(/Banner \d/).textContent;
+
+    swipe(container, 300, 100); // drag left by 200px
+
+    const after = screen.getByText(/Banner \d/).textContent;
+    expect(after).not.toBe(first);
+  });
+
+  it("moves to the previous banner on a right swipe", () => {
+    const { container } = render(<BannerCarousel initialBanners={banners} />);
+
+    swipe(container, 100, 300); // next
+    const afterFirstSwipe = screen.getByText(/Banner \d/).textContent;
+
+    swipe(container, 300, 100); // back (left swipe reverses it)
+
+    const afterSecondSwipe = screen.getByText(/Banner \d/).textContent;
+    expect(afterSecondSwipe).not.toBe(afterFirstSwipe);
+  });
+
+  it("ignores drags shorter than the swipe threshold", () => {
+    const { container } = render(<BannerCarousel initialBanners={banners} />);
+    const before = screen.getByText(/Banner \d/).textContent;
+
+    swipe(container, 200, 210); // only 10px, below threshold
+
+    const after = screen.getByText(/Banner \d/).textContent;
+    expect(after).toBe(before);
+  });
+
+  it("suppresses navigation click after a swipe gesture", () => {
+    const { container } = render(<BannerCarousel initialBanners={banners} />);
+    const link = container.querySelector("a") as HTMLAnchorElement;
+
+    swipe(container, 300, 100);
+
+    const clickEvent = new MouseEvent("click", { bubbles: true, cancelable: true });
+    link.dispatchEvent(clickEvent);
+
+    expect(clickEvent.defaultPrevented).toBe(true);
+  });
+});

--- a/components/BannerCarousel.tsx
+++ b/components/BannerCarousel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { BlueprintCorners } from "@posselect/ui";
@@ -14,9 +14,13 @@ interface Banner {
   bgColor: string;
 }
 
+const SWIPE_THRESHOLD_PX = 50;
+
 export default function BannerCarousel({ initialBanners }: { initialBanners: Banner[] }) {
   const [banners, setBanners] = useState<Banner[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
+  const dragStartX = useRef<number | null>(null);
+  const didSwipe = useRef(false);
 
   useEffect(() => {
     // Shuffle the banners on the client side for random, even exposure
@@ -31,6 +35,39 @@ export default function BannerCarousel({ initialBanners }: { initialBanners: Ban
     }, 5000);
     return () => clearInterval(timer);
   }, [banners.length]);
+
+  const goToRelative = (offset: number) => {
+    setCurrentIndex((prev) => (prev + offset + banners.length) % banners.length);
+  };
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    dragStartX.current = e.clientX;
+    didSwipe.current = false;
+    e.currentTarget.setPointerCapture(e.pointerId);
+  };
+
+  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (dragStartX.current === null) return;
+    if (Math.abs(e.clientX - dragStartX.current) > 10) {
+      didSwipe.current = true;
+    }
+  };
+
+  const endDrag = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (dragStartX.current === null) return;
+    const diff = e.clientX - dragStartX.current;
+    dragStartX.current = null;
+    if (Math.abs(diff) > SWIPE_THRESHOLD_PX) {
+      goToRelative(diff < 0 ? 1 : -1);
+    }
+  };
+
+  const handleLinkClick = (e: React.MouseEvent) => {
+    if (didSwipe.current) {
+      e.preventDefault();
+      didSwipe.current = false;
+    }
+  };
 
   if (banners.length === 0) {
     // Fallback to first banner for SSR or before client hydration
@@ -57,8 +94,14 @@ export default function BannerCarousel({ initialBanners }: { initialBanners: Ban
   const currentBanner = banners[currentIndex];
 
   return (
-    <div style={{ position: "relative", overflow: "hidden", borderRadius: "var(--radius-lg)" }}>
-      <Link href={currentBanner.link} style={{ textDecoration: "none" }}>
+    <div
+      style={{ position: "relative", overflow: "hidden", borderRadius: "var(--radius-lg)", touchAction: "pan-y" }}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
+    >
+      <Link href={currentBanner.link} style={{ textDecoration: "none" }} onClick={handleLinkClick} draggable={false}>
         <div className="card blueprint elev-md hero" style={{ background: currentBanner.bgColor, cursor: "pointer", transition: "background-color 0.5s ease" }}>
           <BlueprintCorners />
           <div className="hero-title" style={{ color: "#fff", position: "relative", zIndex: 10 }}>{currentBanner.title}</div>


### PR DESCRIPTION
## Summary
- `components/BannerCarousel.tsx`가 5초 자동 롤링·dot 클릭 전환만 지원하고 터치/드래그 스와이프에는 반응하지 않던 문제 수정
- Pointer 이벤트(`onPointerDown/Move/Up/Cancel`)로 좌우 드래그를 감지해 배너를 전환 (임계값 50px)
- 스와이프 직후 발생하는 click이 배너 링크로 오탐 네비게이션되지 않도록 억제
- `touchAction: pan-y`로 세로 스크롤은 그대로 두고 가로 스와이프만 가로챔

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (신규 `BannerCarousel.test.tsx` 포함 9/9 통과: 좌스와이프→다음, 우스와이프→이전, 임계값 미만 무시, 스와이프 후 클릭 네비게이션 억제)
- [ ] 로컬 dev 서버 브라우저 실측은 이 워크트리 환경에서 `@posselect/ui` import 시 `react.createContext is not a function`으로 500이 나서 불가 — **clean origin/main 체크아웃에서도 동일 재현되는, 이 변경과 무관한 기존 dev 환경 이슈**로 확인함. 배포 후 home.posselect.com 모바일/터치 환경에서 육안 확인 권장.

Resolves #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)
