### PR TITLE
chore(deps): @posselect/ui 를 fc80407 로 갱신 (EmptyState 아이콘 중앙정렬, posselect-ui#35)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1405,7 +1405,7 @@
     },
     "node_modules/@posselect/ui": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/lee-dohyun/posselect-ui.git#839bf4ea8adef79b5bea0a5b031fb6a02f64bf57",
+      "resolved": "git+ssh://git@github.com/lee-dohyun/posselect-ui.git#fc804073602264b33ef0198cbf5f436d104f819d",
       "peerDependencies": {
         "react": ">=18",
         "tailwindcss": ">=3"


### PR DESCRIPTION
## 무엇

`posselect-ui#35`(EmptyState 아이콘이 좌측 끝에 붙는 버그) 수정 [PR #36](https://github.com/lee-dohyun/posselect-ui/pull/36) 을 이 저장소로 전파한다.

`@posselect/ui` 는 npm 레지스트리가 아니라 **git 의존성**이라 `package-lock.json` 이 커밋을 고정한다. posselect-ui 의 CI 는 Storybook 문서 사이트만 배포하므로, **이 저장소를 재빌드하기 전까지 실제 화면은 계속 옛 CSS 를 쓴다.**

`@posselect/ui` 소스 변경 내용은 `tokens.css` 의 `.empty-state-icon` 한 줄뿐이라 이 저장소의 코드 변경은 없다.

```diff
-.empty-state-icon { color: var(--color-accent-400); margin: 0 auto 16px; display: block; }
+.empty-state-icon { color: var(--color-accent-400); display: flex; justify-content: center; margin-bottom: 16px; }
```

## 검증 (실측)

- `npm run typecheck` 통과
- `npm run build` 성공
- 설치된 `node_modules/@posselect/ui/src/styles/tokens.css:436` 에 수정본이 들어온 것 확인
- lock 의 resolved 커밋이 `fc804073602264b33ef0198cbf5f436d104f819d` 로 갱신된 것 확인

`posselect-ui-propagate` 스킬 절차대로 소비 저장소 5곳(customer/store/product/admin.front + posselect-shell)을 **모두** 함께 올린다 — 하나를 빠뜨리면 헤더/푸터가 서로 다른 버전을 쓰는 과거 사고가 재현된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)